### PR TITLE
Added support for special "w1" device.

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -23,7 +23,7 @@ owhttpd server is exposed via **Ingress (Open Web UI)**
 
 ### Option: `device`
 
-Specify owserver device. 
+Specify owserver device, if using the "serial_or_i2c" type.
 
 ### Option: `device_type`
 
@@ -31,7 +31,10 @@ Specify owserver device_type from the options below:
 - serial_or_i2c device
 - usb device
 - ha7net device
+- w1 device (direct access via GPIO on RasPi)
 - fake device (random simulated device)
+
+Specify "/dev/null" as device, if using usb/ha7net/w1/fake type.
 
 ### Option: `temperature_scale`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apk add --no-cache --virtual .build-deps alpine-keys bash automake make git 
     --enable-ftdi \
     --enable-usb \
     --enable-owshell \
+    --enable-w1 \
   && make -j $CPUS && make install \
   && cd / && rm -rf /owfs-code && apk del .build-deps
 	

--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ options:
 schema:
   owhttpd: bool
   device: device
-  device_type: list(serial_or_i2c|usb|ha7net|fake)
+  device_type: list(serial_or_i2c|usb|ha7net|w1|fake)
   temperature_scale: list(Celsius|Fahrenheit|Kelvin|Rankine)
   ha7net_server: str?
   debug: bool?

--- a/rootfs/etc/cont-init.d/owserver.sh
+++ b/rootfs/etc/cont-init.d/owserver.sh
@@ -21,6 +21,9 @@ elif bashio::var.equals "${device_type}" "ha7net"; then
         bashio::log.error "No ha7net server provided, using FAKE device instead!"
         sed -i "s/%%device%%/FAKE = DS18B20,DS2405/g" /etc/owfs.conf
     fi
+elif  bashio::var.equals "${device_type}" "w1"; then
+    bashio::log.info "Configuring w1 (direct access via GPIO on RasPi)"
+    sed -i "s/%%device%%/w1/g" /etc/owfs.conf
 else
     bashio::log.info "Configuring ${device} device"
     device=$(bashio::string.replace ${device} '/' '\/')


### PR DESCRIPTION
Added option to support die Raspberry Pi direct w1 device.
You need to add the following line to the "config.txt" file on the /dev/mmcblk0p1 partition:
 `dtoverlay=w1-gpio.gpiopin=4`
Additionally I added some short config instructions.
