### PR TITLE
Added option to support PBM

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -23,13 +23,14 @@ owhttpd server is exposed via **Ingress (Open Web UI)**
 
 ### Option: `device`
 
-Specify owserver device, if using the "serial_or_i2c" type.
+Specify owserver device, if using the "serial_or_i2c" type or "pbm" type.
 
 ### Option: `device_type`
 
 Specify owserver device_type from the options below:
 - serial_or_i2c device
 - usb device
+- pbm device (ElabNET's Professioinal Bumster PBM-01)
 - ha7net device
 - w1 device (direct access via GPIO on RasPi)
 - fake device (random simulated device)
@@ -40,9 +41,9 @@ Specify "/dev/null" as device, if using usb/ha7net/w1/fake type.
 
 Specify temperature scale used by owserver from the options below:
 - Celsius _default_
-- Fahrenheit 
-- Kelvin 
-- Rankine 
+- Fahrenheit
+- Kelvin
+- Rankine
 
 ### Option: `ha7net_server`
 

--- a/config.yaml
+++ b/config.yaml
@@ -6,12 +6,12 @@ description: onewire server to read 1-Wire devices
 url: https://github.com/lrybak/hassio-owserver
 startup: system
 init: false
-arch: 
+arch:
   - amd64
   - aarch64
   - armhf
   - armv7
-boot: auto  
+boot: auto
 uart: true
 options:
   owhttpd: true
@@ -19,7 +19,7 @@ options:
 schema:
   owhttpd: bool
   device: device
-  device_type: list(serial_or_i2c|usb|ha7net|w1|fake)
+  device_type: list(serial_or_i2c|usb|pbm|ha7net|w1|fake)
   temperature_scale: list(Celsius|Fahrenheit|Kelvin|Rankine)
   ha7net_server: str?
   debug: bool?

--- a/rootfs/etc/cont-init.d/owserver.sh
+++ b/rootfs/etc/cont-init.d/owserver.sh
@@ -13,6 +13,10 @@ if  bashio::var.equals "${device_type}" "fake"; then
 elif bashio::var.equals "${device_type}" "usb"; then
     bashio::log.info "Configuring usb device"
     sed -i "s/%%device%%/usb = all/g" /etc/owfs.conf
+elif bashio::var.equals "${device_type}" "pbm"; then
+    bashio::log.info "Configuring Professional Busmaster device at ${device}"
+    device=$(bashio::string.replace ${device} '/' '\/')
+    sed -i "s/%%device%%/usb = all\nserver: usb = scan\npbm = ${device}/g" /etc/owfs.conf
 elif bashio::var.equals "${device_type}" "ha7net"; then
     if  bashio::config.exists "ha7net_server"; then
         bashio::log.info "Configuring ha7net device"


### PR DESCRIPTION
Added option to support ElabNET's Professional Busmaster PBM-01 as 1-wire master.
New option "pbm" for device type added, and configuration settings for /etc/owfs.conf added. Documentation enhanced accordingly.

Details for device see at manufacturer: https://shop.elabnet.de/en/1-wire/series/h/1-wire-professional-bus-master-pbm01-usb_812_2073
It's normally available as /dev/ttyUSBx, but link is found also in /de/serial/by-id/ which is preferable as device.