### PR TITLE
Add passive device type and optionally specify usb device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+- Added new device type "passive" for special serial devices.
+- Added possibility to optionally specify device name of usb device.
+
 ## 0.5.0
 - Ability to add multiple 1-Wire devices - **breaking change**, requires addon re-configuration
 - Update hassio-addons/addon-base to v15.3.4

--- a/DOCS.md
+++ b/DOCS.md
@@ -38,6 +38,7 @@ This option allows you to specify list of 1-Wire devices.
 
 Specify the owserver device type from the following options:
 - serial
+- passive (passive serial device)
 - i2c
 - usb
 - pbm (ElabNET's Professioinal Bumster PBM-01)
@@ -50,6 +51,7 @@ Specify the owserver device type from the following options:
 Specify the device.
 This is mandatory option only for following **device_type**:
 - serial
+- passive
 - i2c
 - pbm
 

--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ options:
   temperature_scale: Celsius
 schema:
   devices:
-    - device_type: list(serial|i2c|usb|pbm|ha7net|w1|fake)
+    - device_type: list(serial|passive|i2c|usb|pbm|ha7net|w1|fake)
       device: device?
       ha7net_server: match(^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$)?
   owhttpd: bool

--- a/rootfs/etc/cont-init.d/owserver.sh
+++ b/rootfs/etc/cont-init.d/owserver.sh
@@ -3,6 +3,7 @@
 # validating user's options
 for device in $(bashio::config "devices|keys"); do
     if bashio::config.equals "devices[${device}].device_type" "serial" || \
+        bashio::config.equals "devices[${device}].device_type" "passive" || \
         bashio::config.equals "devices[${device}].device_type" "i2c" || \
         bashio::config.equals "devices[${device}].device_type" "pbm"; then
         if ! bashio::config.has_value "devices[${device}].device"; then

--- a/rootfs/etc/owfs.template.conf
+++ b/rootfs/etc/owfs.template.conf
@@ -5,10 +5,10 @@
 ### {{ .device_type }}
 {{- if eq .device_type "fake" }}
 server: FAKE = DS18B20
-{{- else if and (eq .device_type "usb") (eq .device "" ) }}
-server: usb = all
-{{- else if eq .device_type "usb" }}
+{{- else if and (eq .device_type "usb") .device }}
 server: usb = {{ .device }}
+{{- else if eq .device_type "usb" }}
+server: usb = all
 {{- else if eq .device_type "pbm" }}
 server: usb = all
 server: usb = scan
@@ -17,7 +17,9 @@ pbm = {{ .device }}
 server: ha7net = {{ .ha7net_server }}
 {{- else if eq .device_type "w1" }}
 server: w1
-{{- else if or (or (eq .device_type "serial") (eq .device_type "passive")) (eq .device_type "i2c") }}
+{{- else if eq .device_type "passive" }}
+server: passive = {{ .device }}
+{{- else if or (eq .device_type "serial") (eq .device_type "i2c") }}
 server: device = {{ .device }}
 {{- end }}
 {{- end }}

--- a/rootfs/etc/owfs.template.conf
+++ b/rootfs/etc/owfs.template.conf
@@ -5,8 +5,10 @@
 ### {{ .device_type }}
 {{- if eq .device_type "fake" }}
 server: FAKE = DS18B20
-{{- else if eq .device_type "usb" }}
+{{- else if and (eq .device_type "usb") (eq .device "" ) }}
 server: usb = all
+{{- else if eq .device_type "usb" }}
+server: usb = {{ .device }}
 {{- else if eq .device_type "pbm" }}
 server: usb = all
 server: usb = scan
@@ -15,7 +17,7 @@ pbm = {{ .device }}
 server: ha7net = {{ .ha7net_server }}
 {{- else if eq .device_type "w1" }}
 server: w1
-{{- else if or (eq .device_type "serial") (eq .device_type "i2c") }}
+{{- else if or (or (eq .device_type "serial") (eq .device_type "passive")) (eq .device_type "i2c") }}
 server: device = {{ .device }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- Added new device type "passive" for special serial devices.
   This device type is common on USB adapters with an DS9097. 
   https://owfs.org/index_php_page_usb-usb9097.html
- Added possibility to optionally specify device name of usb device.
   In the HomeAssistant environment I need to specify the usb device
   (for instance for a DS9490R USB adapter), otherwise it will not be found.
