### PR TITLE
Fix for issue  #20: multiple DS2482's on a single I2C channel

### DIFF
--- a/rootfs/etc/owfs.template.conf
+++ b/rootfs/etc/owfs.template.conf
@@ -19,7 +19,9 @@ server: ha7net = {{ .ha7net_server }}
 server: w1
 {{- else if eq .device_type "passive" }}
 server: passive = {{ .device }}
-{{- else if or (eq .device_type "serial") (eq .device_type "i2c") }}
+{{- else if eq .device_type "i2c" }}
+server: i2c = {{ .device }}:ALL
+{{- else if eq .device_type "serial" }}
 server: device = {{ .device }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Appending :ALL after the device name will make owserver look for all  DS2482's on the I2C channel. Alternatively, no device name and ALL:ALL can be used. But this will forbid the docker container access to the corresponding device file, so I think using this solution is better.

The fix is tested and works. 

I did not test using multiple I2C channels simultaneously, but I guess that should work by adding multiple 'device_type' options to the config with the different I2C device files.

