### PR TITLE
Bump addon base image

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@
 
 - [ ] `make lint` passes (Hadolint, ShellCheck, YAMLlint)
 - [ ] `bash dev/test.sh` passes (build and integration tests)
+- [ ] `make test` passes (pytest)
 - [ ] CI checks have passes
 - [ ] I have updated documentation where applicable
 - [ ] I have tested on real hardware or in debug mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.0
+- Bump addon base image to 21.0.0
+
 ## 0.9.0
 - Expose owfs port to network 
 - Fixed: owhttpd was incorrectly starting even when disabled in settings (fixes #73)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.10.0
+## 0.9.1
 - Bump addon base image to 21.0.0
+- Bump builder alpine to alpine:3.24
 
 ## 0.9.0
 - Expose owfs port to network 

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:20.0.4
-  amd64: ghcr.io/hassio-addons/base/amd64:20.0.4
+  aarch64: ghcr.io/hassio-addons/base/aarch64:21.0.0
+  amd64: ghcr.io/hassio-addons/base/amd64:21.0.0


### PR DESCRIPTION
## Description

- Bump addon base image to 21.0.0

## Checklist

- [x] `make lint` passes (Hadolint, ShellCheck, YAMLlint)
- [x] `bash dev/test.sh` passes (build and integration tests)
- [x] `make test` passes (pytest)
- [x] CI checks have passes
- [x] I have updated documentation where applicable
- [x] I have tested on real hardware or in debug mode
